### PR TITLE
Fix value representation for numpy 2.X compatibility

### DIFF
--- a/python/pil.py
+++ b/python/pil.py
@@ -69,6 +69,8 @@ class Pil(object):
                 return value
     def __setitem__(self, name, value):
         if name in self.names:
+            if hasattr(value, 'item'):
+                value = value.item()            
             self.params[name][2] = repr(value)
         elif self.raiseKeyErrors:
             raise KeyError(name)


### PR DESCRIPTION
Fixing the issue discussed in https://github.com/fermi-lat/sane/issues/3.
The issue is that in numpy 2.x, the representation of a scalar value has changed and `repr(np.float64(100.975))` returns the string `np.float64(100.975)` instead of `100.975` as it was in older numpy versions.

This PR introduces `value.item()` to return `100.975` instead of `np.float64(100.975)` to fix numpy 2.X representation.

A few follow-up questions:
Will this be tested in CI (or somewhere else ?) to confirm that it is compatible with numpy 2 ?
Is there anything else that needs to be changed regarding numpy version specification.
Like modifying the azure-pipelines.yml ?